### PR TITLE
CLI merges FASTA headers when querying with multiple same peptides

### DIFF
--- a/lib/unipept/commands/api_runner.rb
+++ b/lib/unipept/commands/api_runner.rb
@@ -190,7 +190,8 @@ module Unipept::Commands
             if sub[j].start_with? '>'
               fasta_header = sub[j]
             else
-              fasta_mapper[sub[j]] = fasta_header
+              fasta_mapper[sub[j]] ||= []
+              fasta_mapper[sub[j]] << fasta_header
             end
             j += 1
           end

--- a/lib/unipept/commands/api_runner.rb
+++ b/lib/unipept/commands/api_runner.rb
@@ -184,18 +184,20 @@ module Unipept::Commands
         fasta_header = first.chomp
         peptides.each_slice(batch_size).with_index do |sub,i|
           fasta_mapper = {}
+          fasta_headers = []
           sub.map! {|s| s.chomp}
           j = 0
           while j < sub.size
             if sub[j].start_with? '>'
               fasta_header = sub[j]
+              fasta_headers << fasta_header
             else
               fasta_mapper[sub[j]] ||= []
               fasta_mapper[sub[j]] << fasta_header
             end
             j += 1
           end
-          sub -= fasta_mapper.values.flatten.uniq
+          sub -= fasta_headers
           block.call(sub, i, fasta_mapper)
         end
       else

--- a/lib/unipept/commands/api_runner.rb
+++ b/lib/unipept/commands/api_runner.rb
@@ -195,7 +195,7 @@ module Unipept::Commands
             end
             j += 1
           end
-          sub -= fasta_mapper.values.uniq
+          sub -= fasta_mapper.values.flatten.uniq
           block.call(sub, i, fasta_mapper)
         end
       else

--- a/lib/unipept/formatters.rb
+++ b/lib/unipept/formatters.rb
@@ -66,16 +66,11 @@ module Unipept
 
     def format(data, fasta_mapper = nil)
       CSV.generate do |csv|
-        occurence_map = {}
         data.each do |o|
           if o.kind_of? Array
             o.each do |h|
               if fasta_mapper
-                occurence_map[h.values.first] ||= 0
-                occurence_map[h.values.first] += 1
-
-                extra_key = [fasta_mapper[h.values.first][(occurence_map[h.values.first] - 1) / (data.map { |d| d.values.first }.count(h.values.first) / fasta_mapper[h.values.first].length)]]
-
+                extra_key = [fasta_mapper[h.values.first].shift]
                 csv << (extra_key + h.values).map { |v| v == ""  ? nil : v }
               else
                 csv << h.values.map { |v| v == ""  ? nil : v }
@@ -83,11 +78,7 @@ module Unipept
             end
           else
             if fasta_mapper
-              occurence_map[o.values.first] ||= 0
-              occurence_map[o.values.first] += 1
-
-              extra_key = [fasta_mapper[o.values.first][(occurence_map[o.values.first] - 1) / (data.map { |d| d.values.first }.count(o.values.first) / fasta_mapper[o.values.first].length)]]
-
+              extra_key = [fasta_mapper[o.values.first].shift]
               csv << (extra_key + o.values).map { |v| v == ""  ? nil : v }
             else
               csv << o.values.map { |v| v == ""  ? nil : v }

--- a/lib/unipept/formatters.rb
+++ b/lib/unipept/formatters.rb
@@ -66,11 +66,16 @@ module Unipept
 
     def format(data, fasta_mapper = nil)
       CSV.generate do |csv|
+        occurence_map = {}
         data.each do |o|
           if o.kind_of? Array
             o.each do |h|
               if fasta_mapper
-                extra_key = [fasta_mapper[h.values.first]]
+                occurence_map[h.values.first] ||= 0
+                occurence_map[h.values.first] += 1
+
+                extra_key = [fasta_mapper[h.values.first][(occurence_map[h.values.first] - 1) / (data.map { |d| d.values.first }.count(h.values.first) / fasta_mapper[h.values.first].length)]]
+
                 csv << (extra_key + h.values).map { |v| v == ""  ? nil : v }
               else
                 csv << h.values.map { |v| v == ""  ? nil : v }
@@ -78,7 +83,11 @@ module Unipept
             end
           else
             if fasta_mapper
-              extra_key = [fasta_mapper[o.values.first]]
+              occurence_map[o.values.first] ||= 0
+              occurence_map[o.values.first] += 1
+
+              extra_key = [fasta_mapper[o.values.first][(occurence_map[o.values.first] - 1) / (data.map { |d| d.values.first }.count(o.values.first) / fasta_mapper[o.values.first].length)]]
+
               csv << (extra_key + o.values).map { |v| v == ""  ? nil : v }
             else
               csv << o.values.map { |v| v == ""  ? nil : v }


### PR DESCRIPTION
This branch fixes both #12 and #17.

When querying the Unipept API through the CLI with a FASTA file containing multiple of the same peptides, the resulting output contains 1 single FASTA header instead of the header for these peptides. See the following example:

```
$ cat data/IITHPNFNGNTLDNDIMLIK 
>a|1
IITHPNFNGNTLDNDIMLIK
>b|2
IITHPNFNGNTLDNDIMLIK
$ unipept pept2prot -i data/IITHPNFNGNTLDNDIMLIK
fasta_header,peptide,uniprot_id,taxon_id
>b|2,IITHPNFNGNTLDNDIMLIK,P00761,9823
>b|2,IITHPNFNGNTLDNDIMLIK,C5IWV5,9823
>b|2,IITHPNFNGNTLDNDIMLIK,F1SRS2,9823
>b|2,IITHPNFNGNTLDNDIMLIK,P00761,9823
>b|2,IITHPNFNGNTLDNDIMLIK,C5IWV5,9823
>b|2,IITHPNFNGNTLDNDIMLIK,F1SRS2,9823
$ unipept pept2lca -i data/IITHPNFNGNTLDNDIMLIK 
fasta_header,peptide,taxon_id,taxon_name,taxon_rank
>b|2,IITHPNFNGNTLDNDIMLIK,9823,Sus scrofa,species
>b|2,IITHPNFNGNTLDNDIMLIK,9823,Sus scrofa,species
```

Is this expected behaviour?


_[Original pull request](https://github.ugent.be/unipept/unipept-cli/pull/12) by @silox on Tue Dec 16 2014 at 00:28._
_Merged by @silox on Wed Apr 08 2015 at 18:17._