### PR TITLE
Add hidden arguments for batch_size and parallel requests

### DIFF
--- a/lib/commands/unipept.rb
+++ b/lib/commands/unipept.rb
@@ -51,6 +51,7 @@ module Unipept
         flag :q, :quiet, 'disable service messages'
         option :i, :input, 'read input from file', argument: :required
         option nil, :batch, 'specify the batch size', argument: :required, hidden: true
+        option nil, :parallel, 'specify the number of parallel requests', argument: :required, hidden: true
         option :o, :output, 'write output to file', argument: :required
         option :f, :format, "define the output format (available: #{Unipept::Formatter.available.join ', ' }) (default: #{Unipept::Formatter.default})", argument: :required
 

--- a/lib/commands/unipept.rb
+++ b/lib/commands/unipept.rb
@@ -50,6 +50,7 @@ module Unipept
         flag :v, :version, 'displays the version'
         flag :q, :quiet, 'disable service messages'
         option :i, :input, 'read input from file', argument: :required
+        option nil, :batch, 'specify the batch size', argument: :required, hidden: true
         option :o, :output, 'write output to file', argument: :required
         option :f, :format, "define the output format (available: #{Unipept::Formatter.available.join ', ' }) (default: #{Unipept::Formatter.default})", argument: :required
 

--- a/lib/commands/unipept/api_runner.rb
+++ b/lib/commands/unipept/api_runner.rb
@@ -61,7 +61,11 @@ module Unipept
 
     # returns the effective batch_size of a command
     def batch_size
-      options[:batch] || default_batch_size
+      if options[:batch]
+        options[:batch].to_i
+      else
+        default_batch_size
+      end
     end
 
     # Constructs a request body (a Hash) for set of input strings, using the

--- a/lib/commands/unipept/api_runner.rb
+++ b/lib/commands/unipept/api_runner.rb
@@ -61,7 +61,7 @@ module Unipept
 
     # returns the effective batch_size of a command
     def batch_size
-      default_batch_size
+      options[:batch] || default_batch_size
     end
 
     # Constructs a request body (a Hash) for set of input strings, using the

--- a/lib/commands/unipept/api_runner.rb
+++ b/lib/commands/unipept/api_runner.rb
@@ -54,9 +54,14 @@ module Unipept
       $stdin.each_line
     end
 
-    # Returns the default batch_size of a command.
-    def batch_size
+    # Returns the default default_batch_size of a command.
+    def default_batch_size
       100
+    end
+
+    # returns the effective batch_size of a command
+    def batch_size
+      default_batch_size
     end
 
     # Constructs a request body (a Hash) for set of input strings, using the

--- a/lib/commands/unipept/pept2lca.rb
+++ b/lib/commands/unipept/pept2lca.rb
@@ -1,7 +1,7 @@
 require_relative 'api_runner'
 module Unipept::Commands
   class Pept2lca < ApiRunner
-    def batch_size
+    def default_batch_size
       if options[:all]
         100
       else

--- a/lib/commands/unipept/pept2prot.rb
+++ b/lib/commands/unipept/pept2prot.rb
@@ -2,7 +2,7 @@ require_relative 'api_runner'
 
 module Unipept::Commands
   class Pept2prot < ApiRunner
-    def batch_size
+    def default_batch_size
       if options[:all]
         5
       else

--- a/lib/commands/unipept/pept2taxa.rb
+++ b/lib/commands/unipept/pept2taxa.rb
@@ -1,7 +1,7 @@
 require_relative 'api_runner'
 module Unipept::Commands
   class Pept2taxa < ApiRunner
-    def batch_size
+    def default_batch_size
       if options[:all]
         5
       else

--- a/lib/commands/unipept/taxa2lca.rb
+++ b/lib/commands/unipept/taxa2lca.rb
@@ -5,7 +5,7 @@ module Unipept::Commands
       SimpleBatchIterator.new
     end
 
-    def batch_size
+    def default_batch_size
       fail 'NOT NEEDED FOR TAXA2LCA'
     end
   end

--- a/lib/commands/unipept/taxonomy.rb
+++ b/lib/commands/unipept/taxonomy.rb
@@ -1,7 +1,7 @@
 require_relative 'api_runner'
 module Unipept::Commands
   class Taxonomy < ApiRunner
-    def batch_size
+    def default_batch_size
       100
     end
   end

--- a/test/commands/unipept/test_api_runner.rb
+++ b/test/commands/unipept/test_api_runner.rb
@@ -108,8 +108,17 @@ module Unipept
       assert_equal(%w(a b c), output)
     end
 
+    def test_default_batch_size
+      assert_equal(100, new_runner.default_batch_size)
+    end
+
     def test_batch_size
       assert_equal(100, new_runner.batch_size)
+    end
+
+    def test_argument_batch_size
+      runner = new_runner('test',  host: 'http://param_host', batch: '123')
+      assert_equal(123, runner.batch_size)
     end
 
     def test_default_formatter

--- a/test/commands/unipept/test_api_runner.rb
+++ b/test/commands/unipept/test_api_runner.rb
@@ -121,6 +121,18 @@ module Unipept
       assert_equal(123, runner.batch_size)
     end
 
+    def test_number_of_parallel_requests
+      assert_equal(10, new_runner.concurrent_requests)
+      runner = new_runner('test',  host: 'http://param_host', parallel: '123')
+      assert_equal(123, runner.concurrent_requests)
+    end
+
+    def test_queue_size
+      assert_equal(200, new_runner.queue_size)
+      runner = new_runner('test',  host: 'http://param_host', parallel: '100')
+      assert_equal(2000, runner.queue_size)
+    end
+
     def test_default_formatter
       runner = new_runner
       assert_equal('csv', runner.formatter.type)

--- a/test/commands/unipept/test_pept2lca.rb
+++ b/test/commands/unipept/test_pept2lca.rb
@@ -2,12 +2,12 @@ require_relative '../../../lib/commands'
 
 module Unipept
   class UnipeptPept2lcaTestCase < Unipept::TestCase
-    def test_batch_size
+    def test_default_batch_size
       command = Cri::Command.define { name 'pept2lca' }
       pept2lca = Commands::Pept2lca.new({ host: 'http://api.unipept.ugent.be' }, [], command)
-      assert_equal(1000, pept2lca.batch_size)
+      assert_equal(1000, pept2lca.default_batch_size)
       pept2lca.options[:all] = true
-      assert_equal(100, pept2lca.batch_size)
+      assert_equal(100, pept2lca.default_batch_size)
     end
 
     def test_help

--- a/test/commands/unipept/test_pept2lca.rb
+++ b/test/commands/unipept/test_pept2lca.rb
@@ -10,10 +10,16 @@ module Unipept
       assert_equal(100, pept2lca.default_batch_size)
     end
 
-    def test_batch_size
+    def test_argument_batch_size
       command = Cri::Command.define { name 'pept2lca' }
       pept2lca = Commands::Pept2lca.new({ host: 'http://api.unipept.ugent.be', batch: '123' }, [], command)
       assert_equal(123, pept2lca.batch_size)
+    end
+
+    def test_batch_size
+      command = Cri::Command.define { name 'pept2lca' }
+      pept2lca = Commands::Pept2lca.new({ host: 'http://api.unipept.ugent.be' }, [], command)
+      assert_equal(1000, pept2lca.batch_size)
     end
 
     def test_help

--- a/test/commands/unipept/test_pept2lca.rb
+++ b/test/commands/unipept/test_pept2lca.rb
@@ -10,6 +10,12 @@ module Unipept
       assert_equal(100, pept2lca.default_batch_size)
     end
 
+    def test_batch_size
+      command = Cri::Command.define { name 'pept2lca' }
+      pept2lca = Commands::Pept2lca.new({ host: 'http://api.unipept.ugent.be', batch: '123' }, [], command)
+      assert_equal(123, pept2lca.batch_size)
+    end
+
     def test_help
       out, _err = capture_io_while do
         assert_raises SystemExit do

--- a/test/commands/unipept/test_pept2prot.rb
+++ b/test/commands/unipept/test_pept2prot.rb
@@ -2,12 +2,12 @@ require_relative '../../../lib/commands'
 
 module Unipept
   class UnipeptPept2protTestCase < Unipept::TestCase
-    def test_batch_size
+    def test_default_batch_size
       command = Cri::Command.define { name 'pept2prot' }
       pept2prot = Commands::Pept2prot.new({ host: 'http://api.unipept.ugent.be' }, [], command)
-      assert_equal(10, pept2prot.batch_size)
+      assert_equal(10, pept2prot.default_batch_size)
       pept2prot.options[:all] = true
-      assert_equal(5, pept2prot.batch_size)
+      assert_equal(5, pept2prot.default_batch_size)
     end
 
     def test_help

--- a/test/commands/unipept/test_pept2taxa.rb
+++ b/test/commands/unipept/test_pept2taxa.rb
@@ -2,12 +2,12 @@ require_relative '../../../lib/commands'
 
 module Unipept
   class UnipeptPept2taxaTestCase < Unipept::TestCase
-    def test_batch_size
+    def test_default_batch_size
       command = Cri::Command.define { name 'pept2taxa' }
       pept2taxa = Commands::Pept2taxa.new({ host: 'http://api.unipept.ugent.be' }, [], command)
-      assert_equal(10, pept2taxa.batch_size)
+      assert_equal(10, pept2taxa.default_batch_size)
       pept2taxa.options[:all] = true
-      assert_equal(5, pept2taxa.batch_size)
+      assert_equal(5, pept2taxa.default_batch_size)
     end
 
     def test_help

--- a/test/commands/unipept/test_taxa2lca.rb
+++ b/test/commands/unipept/test_taxa2lca.rb
@@ -2,11 +2,11 @@ require_relative '../../../lib/commands'
 
 module Unipept
   class UnipeptTaxa2lcaTestCase < Unipept::TestCase
-    def test_batch_size
+    def test_default_batch_size
       command = Cri::Command.define { name 'taxa2lca' }
       taxa2lca = Commands::Taxa2lca.new({ host: 'http://api.unipept.ugent.be' }, [], command)
       assert_raises RuntimeError do
-        taxa2lca.batch_size
+        taxa2lca.default_batch_size
       end
     end
 

--- a/test/commands/unipept/test_taxonomy.rb
+++ b/test/commands/unipept/test_taxonomy.rb
@@ -2,10 +2,10 @@ require_relative '../../../lib/commands'
 
 module Unipept
   class UnipeptTaxonomyTestCase < Unipept::TestCase
-    def test_batch_size
+    def test_default_batch_size
       command = Cri::Command.define { name 'taxonomy' }
       taxonomy = Commands::Taxonomy.new({ host: 'http://api.unipept.ugent.be' }, [], command)
-      assert_equal(100, taxonomy.batch_size)
+      assert_equal(100, taxonomy.default_batch_size)
     end
 
     def test_help


### PR DESCRIPTION
This PR adds 
- the hidden `--batch` argument to set the batch size of a request. This overrides any set default.
- the hidden `--parallel` argument to set the number of parallel requests (default is 10). The internal queue size is set as 20 times the number of concurrent requests
- reorder the methods in the `api_runner`


_[Original pull request](https://github.ugent.be/unipept/unipept-cli/pull/38) by @bmesuere on Thu Jun 18 2015 at 10:58._
_Merged by @bmesuere on Thu Jun 18 2015 at 15:30._