### PR TITLE
rewrite the output writer

### DIFF
--- a/lib/commands/unipept.rb
+++ b/lib/commands/unipept.rb
@@ -4,6 +4,7 @@ require_relative '../batch_order'
 require_relative '../batch_iterator'
 require_relative '../configuration'
 require_relative '../formatters'
+require_relative '../output_writer'
 require_relative '../server_message'
 require_relative '../version'
 

--- a/lib/commands/unipept/api_runner.rb
+++ b/lib/commands/unipept/api_runner.rb
@@ -51,6 +51,10 @@ module Unipept
       $stdin.each_line
     end
 
+    def output_writer
+      @output_writer ||= OutputWriter.new(options[:output])
+    end
+
     # Returns the default default_batch_size of a command.
     def default_batch_size
       100
@@ -139,16 +143,6 @@ module Unipept
       $stderr.puts "API request failed! log can be found in #{path}"
     end
 
-    # Write a string to the output defined by the command. If a file is given,
-    # write it to the file. If not, write to stdout
-    def write_to_output(string)
-      if options[:output]
-        File.open(options[:output], 'a') { |f| f.write string }
-      else
-        puts string
-      end
-    end
-
     private
 
     def error_file_path
@@ -163,8 +157,8 @@ module Unipept
 
         lambda do
           unless result.empty?
-            write_to_output formatter.header(result, fasta_mapper) if batch_id == 0
-            write_to_output formatter.format(result, fasta_mapper)
+            output_writer.write_line formatter.header(result, fasta_mapper) if batch_id == 0
+            output_writer.write_line formatter.format(result, fasta_mapper)
           end
         end
       elsif response.timed_out?

--- a/lib/output_writer.rb
+++ b/lib/output_writer.rb
@@ -1,16 +1,11 @@
 module Unipept
   class OutputWriter
     def initialize(file)
-      @file  = File.open(file, 'a') if file
-      @stdout = file.nil?
+      @output = file ? File.open(file, 'a') : $stdout
     end
 
     def write_line(string)
-      if @stdout
-        puts string
-      else
-        @file.write string
-      end
+      @output.write string
     end
   end
 end

--- a/lib/output_writer.rb
+++ b/lib/output_writer.rb
@@ -1,0 +1,16 @@
+module Unipept
+  class OutputWriter
+    def initialize(file)
+      @file  = File.open(file, 'a') if file
+      @stdout = file.nil?
+    end
+
+    def write_line(string)
+      if @stdout
+        puts string
+      else
+        @file.write string
+      end
+    end
+  end
+end

--- a/lib/output_writer.rb
+++ b/lib/output_writer.rb
@@ -1,11 +1,13 @@
 module Unipept
   class OutputWriter
+    attr_reader :output
+
     def initialize(file)
       @output = file ? File.open(file, 'a') : $stdout
     end
 
-    def write_line(string)
-      @output.write string
+    def write_line(line)
+      @output.write line
     end
   end
 end

--- a/test/commands/unipept/test_api_runner.rb
+++ b/test/commands/unipept/test_api_runner.rb
@@ -217,23 +217,6 @@ module Unipept
       assert_equal(false, body[:names])
     end
 
-    def test_stdout_write_to_output
-      runner = new_runner
-      out, _err = capture_io_while do
-        runner.write_to_output('hello world')
-      end
-      assert_equal('hello world', out.chomp)
-    end
-
-    def test_file_write_to_output
-      runner = new_runner('test', host: 'test', output: 'output_file')
-      out, _err = capture_io_while do
-        runner.write_to_output('hello world')
-      end
-      assert_equal('', out)
-      assert_equal('hello world', IO.foreach('output_file').next.chomp)
-    end
-
     def test_glob_to_regex
       runner = new_runner
       assert(/^simple$/, runner.glob_to_regex('simple'))

--- a/test/test_output_writer.rb
+++ b/test/test_output_writer.rb
@@ -1,0 +1,29 @@
+require_relative '../lib/output_writer'
+
+module Unipept
+  class OutputWriterTestCase < Unipept::TestCase
+    def test_init
+      assert_equal($stdout, OutputWriter.new(nil).output)
+      assert_equal(File, OutputWriter.new('output.txt').output.class)
+    end
+
+    def test_stdout_write_to_output
+      out, _err = capture_io_while do
+        writer = OutputWriter.new(nil)
+        writer.write_line('hello world')
+        writer.output.flush
+      end
+      assert_equal('hello world', out.chomp)
+    end
+
+    def test_file_write_to_output
+      out, _err = capture_io_while do
+        writer = OutputWriter.new('output_file')
+        writer.write_line('hello world')
+        writer.output.flush
+      end
+      assert_equal('', out)
+      assert_equal('hello world', IO.foreach('output_file').next.chomp)
+    end
+  end
+end


### PR DESCRIPTION
Changes:
- Move output writer to separate class
- Open the file only once
- Use (buffered) `write` for `$stdout`

This fixes #39 


_[Original pull request](https://github.ugent.be/unipept/unipept-cli/pull/40) by @bmesuere on Thu Jun 18 2015 at 21:34._
_Merged by @bmesuere on Thu Jun 18 2015 at 21:35._