### PR TITLE
Implement fasta support for xml and json output

### DIFF
--- a/lib/commands/unipept/api_runner.rb
+++ b/lib/commands/unipept/api_runner.rb
@@ -50,7 +50,7 @@ module Unipept
 
     # Returns the default default_batch_size of a command.
     def default_batch_size
-      100
+      fail NotImplementedError, 'This must be implemented in a subclass.'
     end
 
     # returns the effective batch_size of a command

--- a/lib/formatters.rb
+++ b/lib/formatters.rb
@@ -61,6 +61,10 @@ module Unipept
       ''
     end
 
+    def footer
+      ''
+    end
+
     # Converts the given input data and corresponding fasta headers to another
     # format.
     #
@@ -72,9 +76,9 @@ module Unipept
     # element is the input data
     #
     # @return [String] The converted input data
-    def format(data, fasta_mapper = nil)
+    def format(data, fasta_mapper = nil, first)
       data = integrate_fasta_headers(data, fasta_mapper) if fasta_mapper
-      convert(data)
+      convert(data, first)
     end
 
     # Converts the given input data to another format.
@@ -82,7 +86,7 @@ module Unipept
     # @param [Array] data The data we wish to convert
     #
     # @return [String] The converted input data
-    def convert(data)
+    def convert(data, _first)
       data
     end
 
@@ -123,13 +127,22 @@ module Unipept
       'json'
     end
 
+    def header(_data, _fasta_mapper = nil)
+      '['
+    end
+
+    def footer
+      "]\n"
+    end
+
     # Converts the given input data to the JSON format.
     #
     # @param [Array] data The data we wish to convert
     #
     # @return [String] The converted input data in the JSON format
-    def convert(data)
-      data.to_json
+    def convert(data, first)
+      output = data.map(&:to_json).join(',')
+      first ? output : ',' + output
     end
   end
 
@@ -168,7 +181,7 @@ module Unipept
     # @param [Array] data The data we wish to convert
     #
     # @return [String] The converted input data in the CSV format
-    def convert(data)
+    def convert(data, _first)
       CSV.generate do |csv|
         data.each do |o|
           csv << o.values.map { |v| v == ''  ? nil : v }
@@ -206,13 +219,21 @@ module Unipept
       'xml'
     end
 
+    def header(_data, _fasta_mapper = nil)
+      '<results>'
+    end
+
+    def footer
+      "</results>\n"
+    end
+
     # Converts the given input data to the XML format.
     #
     # @param [Array] data The data we wish to convert
     #
     # @return [String] The converted input data in the XML format
-    def convert(data)
-      data.to_xml
+    def convert(data, _first)
+      data.map { |row| '<result>' + row.to_xml + '</result>' }.join('')
     end
   end
 end

--- a/lib/formatters.rb
+++ b/lib/formatters.rb
@@ -104,7 +104,7 @@ module Unipept
 
     # Groups the data by the first key of each element, for example
     # [{key1: v1, key2: v2},{key1: v1, key2: v3},{key1: v4, key2: v2}]
-    # to {v1 => [{key1: v1, key2: v2},{key1: v1, key2: v3}], v4 => [{key1: v4, key2: v2}]]
+    # to {v1 => [{key1: v1, key2: v2},{key1: v1, key2: v3}], v4 => [{key1: v4, key2: v2}]}
     #
     # @param [Array<Hash>] data The data we wish to group
     #
@@ -188,7 +188,7 @@ module Unipept
 
     class ::Array
       def to_xml(array_name = :array, _item_name = :item)
-        %(<#{array_name} size="#{size}">) + map { |n|n.to_xml(:item) }.join + "</#{array_name}>"
+        %(<#{array_name}>) + map { |n|n.to_xml(:item) }.join + "</#{array_name}>"
       end
     end
 

--- a/lib/formatters.rb
+++ b/lib/formatters.rb
@@ -42,7 +42,7 @@ module Unipept
 
     # @return [String] The type of the current formatter
     def type
-      ''
+      fail NotImplementedError, 'This must be implemented in a subclass.'
     end
 
     # Returns the header row for the given sample_data and fasta_mapper. This
@@ -58,11 +58,15 @@ module Unipept
     #
     # @return [String] The header row
     def header(_sample_data, _fasta_mapper = nil)
-      ''
+      fail NotImplementedError, 'This must be implemented in a subclass.'
     end
 
+    # Returns the footer row. This row is output only once at the end of the
+    # output
+    #
+    # @return [String] The footer row
     def footer
-      ''
+      fail NotImplementedError, 'This must be implemented in a subclass.'
     end
 
     # Converts the given input data and corresponding fasta headers to another
@@ -75,6 +79,8 @@ module Unipept
     # containing tuples where the first element is the fasta header and second
     # element is the input data
     #
+    # @param [Boolean] Is this the first output batch?
+    #
     # @return [String] The converted input data
     def format(data, fasta_mapper = nil, first)
       data = integrate_fasta_headers(data, fasta_mapper) if fasta_mapper
@@ -85,9 +91,11 @@ module Unipept
     #
     # @param [Array] data The data we wish to convert
     #
+    # @param [Boolean] Is this the first output batch?
+    #
     # @return [String] The converted input data
-    def convert(data, _first)
-      data
+    def convert(_data, _first)
+      fail NotImplementedError, 'This must be implemented in a subclass.'
     end
 
     # Integrates the fasta headers into the data object
@@ -139,6 +147,8 @@ module Unipept
     #
     # @param [Array] data The data we wish to convert
     #
+    # @param [Boolean] Is this the first output batch?
+    #
     # @return [String] The converted input data in the JSON format
     def convert(data, first)
       output = data.map(&:to_json).join(',')
@@ -176,9 +186,15 @@ module Unipept
       end
     end
 
+    def footer
+      ''
+    end
+
     # Converts the given input data to the CSV format.
     #
     # @param [Array] data The data we wish to convert
+    #
+    # @param [Boolean] Is this the first output batch?
     #
     # @return [String] The converted input data in the CSV format
     def convert(data, _first)
@@ -230,6 +246,8 @@ module Unipept
     # Converts the given input data to the XML format.
     #
     # @param [Array] data The data we wish to convert
+    #
+    # @param [Boolean] Is this the first output batch?
     #
     # @return [String] The converted input data in the XML format
     def convert(data, _first)

--- a/test/commands/unipept/test_api_runner.rb
+++ b/test/commands/unipept/test_api_runner.rb
@@ -108,11 +108,17 @@ module Unipept
     end
 
     def test_default_batch_size
-      assert_equal(100, new_runner.default_batch_size)
+      assert_raises NotImplementedError do
+        new_runner.default_batch_size
+      end
     end
 
     def test_batch_size
-      assert_equal(100, new_runner.batch_size)
+      r = new_runner
+      def r.default_batch_size
+        100
+      end
+      assert_equal(100, r.batch_size)
     end
 
     def test_argument_batch_size

--- a/test/commands/unipept/test_pept2lca.rb
+++ b/test/commands/unipept/test_pept2lca.rb
@@ -48,5 +48,18 @@ module Unipept
       assert(lines.next.start_with? 'AALTER,1,root,no rank')
       assert_raises(StopIteration) { lines.next }
     end
+
+    def test_run_with_fasta_multiple_batches
+      out, err = capture_io_while do
+        Commands::Unipept.run(%w(pept2lca --host http://api.unipept.ugent.be --batch 2 >test AALTER AALER >tost AALTER))
+      end
+      lines = out.each_line
+      assert_equal('', err)
+      assert(lines.next.start_with? 'fasta_header,peptide,taxon_id')
+      assert(lines.next.start_with? '>test,AALTER,1,root,no rank')
+      assert(lines.next.start_with? '>test,AALER,1,root,no rank')
+      assert(lines.next.start_with? '>tost,AALTER,1,root,no rank')
+      assert_raises(StopIteration) { lines.next }
+    end
   end
 end

--- a/test/commands/unipept/test_pept2lca.rb
+++ b/test/commands/unipept/test_pept2lca.rb
@@ -61,5 +61,30 @@ module Unipept
       assert(lines.next.start_with? '>tost,AALTER,1,root,no rank')
       assert_raises(StopIteration) { lines.next }
     end
+
+    def test_run_with_fasta_multiple_batches_json
+      out, err = capture_io_while do
+        Commands::Unipept.run(%w(pept2lca --host http://api.unipept.ugent.be --batch 2 --format json >test AALTER AALER >tost AALTER))
+      end
+      lines = out.each_line
+      assert_equal('', err)
+      output = lines.to_a.join('').chomp
+      assert(output.start_with? '[')
+      assert(output.end_with? ']')
+      assert(!output.include?('}{'))
+      assert(output.include? 'fasta_header')
+    end
+
+    def test_run_with_fasta_multiple_batches_xml
+      out, err = capture_io_while do
+        Commands::Unipept.run(%w(pept2lca --host http://api.unipept.ugent.be --batch 2 --format xml >test AALTER AALER >tost AALTER))
+      end
+      lines = out.each_line
+      assert_equal('', err)
+      output = lines.to_a.join('').chomp
+      assert(output.start_with? '<results>')
+      assert(output.end_with? '</results>')
+      assert(output.include? '<fasta_header>')
+    end
   end
 end

--- a/test/commands/unipept/test_pept2prot.rb
+++ b/test/commands/unipept/test_pept2prot.rb
@@ -35,5 +35,17 @@ module Unipept
       assert(lines.next.start_with? 'peptide,uniprot_id,taxon_id')
       assert(lines.next.start_with? 'ENFVYIAK,')
     end
+
+    def test_run_with_fasta_multiple_batches
+      out, err = capture_io_while do
+        Commands::Unipept.run(%w(pept2prot --host http://api.unipept.ugent.be --batch 2 >test EGGAGSSTGQR ENFVYIAK >tost EGGAGSSTGQR))
+      end
+      lines = out.each_line
+      assert_equal('', err)
+      assert(lines.next.start_with? 'fasta_header,peptide,uniprot_id,taxon_id')
+      assert(lines.select { |line| line.start_with? '>test,EGGAGSSTGQR,' }.size >= 1)
+      assert(lines.select { |line| line.start_with? '>test,ENFVYIAK,' }.size >= 1)
+      assert(lines.select { |line| line.start_with? '>tost,EGGAGSSTGQR,' }.size >= 1)
+    end
   end
 end

--- a/test/commands/unipept/test_pept2prot.rb
+++ b/test/commands/unipept/test_pept2prot.rb
@@ -47,5 +47,30 @@ module Unipept
       assert(lines.select { |line| line.start_with? '>test,ENFVYIAK,' }.size >= 1)
       assert(lines.select { |line| line.start_with? '>tost,EGGAGSSTGQR,' }.size >= 1)
     end
+
+    def test_run_with_fasta_multiple_batches_json
+      out, err = capture_io_while do
+        Commands::Unipept.run(%w(pept2prot --host http://api.unipept.ugent.be --batch 2 --format json >test EGGAGSSTGQR ENFVYIAK >tost EGGAGSSTGQR))
+      end
+      lines = out.each_line
+      assert_equal('', err)
+      output = lines.to_a.join('').chomp
+      assert(output.start_with? '[')
+      assert(output.end_with? ']')
+      assert(!output.include?('}{'))
+      assert(output.include? 'fasta_header')
+    end
+
+    def test_run_with_fasta_multiple_batches_xml
+      out, err = capture_io_while do
+        Commands::Unipept.run(%w(pept2prot --host http://api.unipept.ugent.be --batch 2 --format xml >test EGGAGSSTGQR ENFVYIAK >tost EGGAGSSTGQR))
+      end
+      lines = out.each_line
+      assert_equal('', err)
+      output = lines.to_a.join('').chomp
+      assert(output.start_with? '<results>')
+      assert(output.end_with? '</results>')
+      assert(output.include? '<fasta_header>')
+    end
   end
 end

--- a/test/commands/unipept/test_pept2taxa.rb
+++ b/test/commands/unipept/test_pept2taxa.rb
@@ -35,5 +35,17 @@ module Unipept
       assert(lines.next.start_with? 'peptide,taxon_id,taxon_name,taxon_rank')
       assert(lines.next.start_with? 'ENFVYIAK,')
     end
+
+    def test_run_with_fasta_multiple_batches
+      out, err = capture_io_while do
+        Commands::Unipept.run(%w(pept2taxa --host http://api.unipept.ugent.be --batch 2 >test EGGAGSSTGQR ENFVYIAK >tost EGGAGSSTGQR))
+      end
+      lines = out.each_line
+      assert_equal('', err)
+      assert(lines.next.start_with? 'fasta_header,peptide,taxon_id,taxon_name,taxon_rank')
+      assert(lines.select { |line| line.start_with? '>test,EGGAGSSTGQR,' }.size >= 1)
+      assert(lines.select { |line| line.start_with? '>test,ENFVYIAK,' }.size >= 1)
+      assert(lines.select { |line| line.start_with? '>tost,EGGAGSSTGQR,' }.size >= 1)
+    end
   end
 end

--- a/test/commands/unipept/test_pept2taxa.rb
+++ b/test/commands/unipept/test_pept2taxa.rb
@@ -47,5 +47,30 @@ module Unipept
       assert(lines.select { |line| line.start_with? '>test,ENFVYIAK,' }.size >= 1)
       assert(lines.select { |line| line.start_with? '>tost,EGGAGSSTGQR,' }.size >= 1)
     end
+
+    def test_run_with_fasta_multiple_batches_json
+      out, err = capture_io_while do
+        Commands::Unipept.run(%w(pept2taxa --host http://api.unipept.ugent.be --batch 2 --format json >test EGGAGSSTGQR ENFVYIAK >tost EGGAGSSTGQR))
+      end
+      lines = out.each_line
+      assert_equal('', err)
+      output = lines.to_a.join('').chomp
+      assert(output.start_with? '[')
+      assert(output.end_with? ']')
+      assert(!output.include?('}{'))
+      assert(output.include? 'fasta_header')
+    end
+
+    def test_run_with_fasta_multiple_batches_xml
+      out, err = capture_io_while do
+        Commands::Unipept.run(%w(pept2taxa --host http://api.unipept.ugent.be --batch 2 --format xml >test EGGAGSSTGQR ENFVYIAK >tost EGGAGSSTGQR))
+      end
+      lines = out.each_line
+      assert_equal('', err)
+      output = lines.to_a.join('').chomp
+      assert(output.start_with? '<results>')
+      assert(output.end_with? '</results>')
+      assert(output.include? '<fasta_header>')
+    end
   end
 end

--- a/test/commands/unipept/test_taxa2lca.rb
+++ b/test/commands/unipept/test_taxa2lca.rb
@@ -35,5 +35,29 @@ module Unipept
       assert(lines.next.start_with? 'taxon_id,taxon_name,taxon_rank')
       assert(lines.next.start_with? '1678,Bifidobacterium,genus')
     end
+
+    def test_run_xml
+      out, err = capture_io_while do
+        Commands::Unipept.run(%w(taxa2lca --host http://api.unipept.ugent.be --format xml 216816 1680))
+      end
+      lines = out.each_line
+      output = lines.to_a.join('').chomp
+      assert_equal('', err)
+      assert(output.start_with? '<results>')
+      assert(output.end_with? '</results>')
+    end
+
+    def test_run_json
+      out, err = capture_io_while do
+        Commands::Unipept.run(%w(taxa2lca --host http://api.unipept.ugent.be --format json 216816 1680))
+      end
+      lines = out.each_line
+      output = lines.to_a.join('').chomp
+      assert_equal('', err)
+      assert(output.start_with? '[')
+      assert(output.end_with? ']')
+      assert(!output.include?('}{'))
+      assert(!output.include?(']['))
+    end
   end
 end

--- a/test/commands/unipept/test_taxonomy.rb
+++ b/test/commands/unipept/test_taxonomy.rb
@@ -33,5 +33,17 @@ module Unipept
       assert(lines.next.start_with? 'taxon_id,taxon_name,taxon_rank')
       assert(lines.next.start_with? '1,root,no rank')
     end
+
+    def test_run_with_fasta_multiple_batches
+      out, err = capture_io_while do
+        Commands::Unipept.run(%w(taxonomy --host http://api.unipept.ugent.be --batch 2 >test 1 216816 >tost 1))
+      end
+      lines = out.each_line
+      assert_equal('', err)
+      assert(lines.next.start_with? 'fasta_header,taxon_id,taxon_name,taxon_rank')
+      assert(lines.select { |line| line.start_with? '>test,1,' }.size >= 1)
+      assert(lines.select { |line| line.start_with? '>test,216816,' }.size >= 1)
+      assert(lines.select { |line| line.start_with? '>tost,1,' }.size >= 1)
+    end
   end
 end

--- a/test/commands/unipept/test_taxonomy.rb
+++ b/test/commands/unipept/test_taxonomy.rb
@@ -45,5 +45,30 @@ module Unipept
       assert(lines.select { |line| line.start_with? '>test,216816,' }.size >= 1)
       assert(lines.select { |line| line.start_with? '>tost,1,' }.size >= 1)
     end
+
+    def test_run_with_fasta_multiple_batches_json
+      out, err = capture_io_while do
+        Commands::Unipept.run(%w(taxonomy --host http://api.unipept.ugent.be --batch 2 --format json >test 1 216816 >tost 1))
+      end
+      lines = out.each_line
+      assert_equal('', err)
+      output = lines.to_a.join('').chomp
+      assert(output.start_with? '[')
+      assert(output.end_with? ']')
+      assert(!output.include?('}{'))
+      assert(output.include? 'fasta_header')
+    end
+
+    def test_run_with_fasta_multiple_batches_xml
+      out, err = capture_io_while do
+        Commands::Unipept.run(%w(taxonomy --host http://api.unipept.ugent.be --batch 2 --format xml >test 1 216816 >tost 1))
+      end
+      lines = out.each_line
+      assert_equal('', err)
+      output = lines.to_a.join('').chomp
+      assert(output.start_with? '<results>')
+      assert(output.end_with? '</results>')
+      assert(output.include? '<fasta_header>')
+    end
   end
 end

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -33,6 +33,19 @@ module Unipept
       assert_equal('csv', formatter.type)
     end
 
+    def test_group_by_first_key
+      array = [{ key1: 'v1', key2: 'v2' }, { key1: 'v1', key2: 'v3' }, { key1: 'v4', key2: 'v2' }]
+      grouped = formatter.group_by_first_key(array)
+      assert_equal({ 'v1' => [{ key1: 'v1', key2: 'v2' }, { key1: 'v1', key2: 'v3' }], 'v4' => [{ key1: 'v4', key2: 'v2' }] }, grouped)
+    end
+
+    def test_integrate_fasta_headers
+      fasta = [['>test', '5']]
+      object = [TestObject.test_object, TestObject.test_object]
+      integrated = Array.new(2, { fasta_header: '>test' }.merge(TestObject.test_object))
+      assert_equal(integrated, formatter.integrate_fasta_headers(object, fasta))
+    end
+
     def formatter
       Formatter.new
     end
@@ -65,6 +78,13 @@ module Unipept
 
     def test_format
       assert_equal(TestObject.as_json, formatter.format(TestObject.test_object))
+    end
+
+    def test_format_with_fasta
+      fasta = [['>test', '5']]
+      output = formatter.format([TestObject.test_object], fasta)
+      json = '[{"fasta_header":">test","integer":5,"string":"string","list":["a",2,false]}]'
+      assert_equal(json, output)
     end
   end
 
@@ -114,6 +134,13 @@ module Unipept
     def test_format
       assert_equal(TestObject.as_xml, formatter.format(TestObject.test_object))
     end
+
+    def test_format_with_fasta
+      fasta = [['>test', '5']]
+      output = formatter.format([TestObject.test_object], fasta)
+      xml = '<array><item><fasta_header>>test</fasta_header>' + TestObject.as_xml + '</item></array>'
+      assert_equal(xml, output)
+    end
   end
 
   class TestObject
@@ -126,7 +153,7 @@ module Unipept
     end
 
     def self.as_xml
-      '<integer>5</integer><string>string</string><list size="3"><item>a</item><item>2</item><item>false</item></list>'
+      '<integer>5</integer><string>string</string><list><item>a</item><item>2</item><item>false</item></list>'
     end
 
     def self.as_csv


### PR DESCRIPTION
There were some issues with the xml and json output that are fixed with this PR:
- The fasta headers were only included in the csv output and not in the xml and json output.
- The conversion was done per batch, meaning it resulted in invalid xml and json: `[res1,res2][res3,res4]` while this should be `[res1,res2,res3,res4]` 

Closes #41 


_[Original pull request](https://github.ugent.be/unipept/unipept-cli/pull/42) by @bmesuere on Fri Jun 19 2015 at 15:29._
_Merged by @bmesuere on Sun Jun 21 2015 at 21:04._