### PR TITLE
add the meganize flag to pept2prot

### DIFF
--- a/lib/commands/unipept.rb
+++ b/lib/commands/unipept.rb
@@ -180,6 +180,7 @@ module Unipept
         flag :e, :equate, 'equate isoleucine (I) and leucine (L) when matching peptides'
         flag :a, :all, 'report all information fields of UniProt entries available in Unipept. Note that this may have a performance penalty.'
         option :s, :select, 'select the information fields to return. Selected fields are passed as a comma separated list of field names. Multiple -s (or --select) options may be used.', argument: :required, multiple: true
+        option nil, :meganize, 'output the results in a BlastTab-like format that MEGAN can understand'
 
         runner Commands::Pept2prot
       end

--- a/lib/commands/unipept/pept2prot.rb
+++ b/lib/commands/unipept/pept2prot.rb
@@ -2,6 +2,15 @@ require_relative 'api_runner'
 
 module Unipept::Commands
   class Pept2prot < ApiRunner
+    def initialize(args, opts, cmd)
+      if args[:meganize]
+        args[:all] = true
+        args[:select] = ['peptide,refseq_protein_ids']
+        args[:format] = 'blast'
+      end
+      super
+    end
+
     def required_fields
       ['peptide']
     end

--- a/lib/formatters.rb
+++ b/lib/formatters.rb
@@ -254,4 +254,37 @@ module Unipept
       data.map { |row| '<result>' + row.to_xml + '</result>' }.join('')
     end
   end
+
+  class BlastFormatter < Formatter
+    register :blast
+
+    # @return [String] The type of the current formatter: blast
+    def type
+      'blast'
+    end
+
+    def header(_data, _fasta_mapper = nil)
+      ''
+    end
+
+    def footer
+      ''
+    end
+
+    # Converts the given input data to the Blast format.
+    #
+    # @param [Array] data The data we wish to convert
+    #
+    # @param [Boolean] Is this the first output batch?
+    #
+    # @return [String] The converted input data in the Blast format
+    def convert(data, _first)
+      data
+        .reject { |o| o['refseq_protein_ids'].empty? }
+        .map do |o|
+          "#{o['peptide']}\tref|#{o['refseq_protein_ids']}|\t100\t10\t0\t0\t0\t10\t0\t10\t1e-100\t100\n"
+        end
+        .join
+    end
+  end
 end

--- a/test/commands/unipept/test_pept2prot.rb
+++ b/test/commands/unipept/test_pept2prot.rb
@@ -16,6 +16,22 @@ module Unipept
       assert_equal(['peptide'], pept2prot.required_fields)
     end
 
+    def test_meganize_options
+      command = Cri::Command.define { name 'pept2prot' }
+      pept2prot = Commands::Pept2prot.new({ meganize: true, host: 'http://api.unipept.ugent.be' }, [], command)
+      assert(pept2prot.options[:all])
+      assert_equal(['peptide,refseq_protein_ids'], pept2prot.options[:select])
+      assert_equal('blast', pept2prot.options[:format])
+    end
+
+    def test_meganize_options_overridecommand
+      command = Cri::Command.define { name 'pept2prot' }
+      pept2prot = Commands::Pept2prot.new({ meganize: true, format: 'xml', all: false, select: ['something'], host: 'http://api.unipept.ugent.be' }, [], command)
+      assert(pept2prot.options[:all])
+      assert_equal(['peptide,refseq_protein_ids'], pept2prot.options[:select])
+      assert_equal('blast', pept2prot.options[:format])
+    end
+
     def test_help
       out, _err = capture_io_while do
         assert_raises SystemExit do

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -7,6 +7,7 @@ module Unipept
       assert(formatters.include?('json'))
       assert(formatters.include?('csv'))
       assert(formatters.include?('xml'))
+      assert(formatters.include?('blast'))
     end
 
     def test_default_formatter
@@ -28,6 +29,9 @@ module Unipept
 
       formatter = Formatter.new_for_format('csv')
       assert_equal('csv', formatter.type)
+
+      formatter = Formatter.new_for_format('blast')
+      assert_equal('blast', formatter.type)
 
       formatter = Formatter.new_for_format('blah')
       assert_equal('csv', formatter.type)
@@ -118,6 +122,31 @@ module Unipept
       output = formatter.format([TestObject.test_object], fasta, true)
       json = '{"fasta_header":">test","integer":5,"string":"string","list":["a",2,false]}'
       assert_equal(json, output)
+    end
+  end
+
+  class BlastFormatterTestCase < Unipept::TestCase
+    def formatter
+      Formatter.new_for_format('blast')
+    end
+
+    def test_header
+      assert_equal('', formatter.header(nil, nil))
+    end
+
+    def test_footer
+      assert_equal('', formatter.footer)
+    end
+
+    def test_type
+      assert_equal('blast', formatter.type)
+    end
+
+    def test_convert
+      object = [{ 'peptide' => 'MDGTEYIIVK', 'refseq_protein_ids' => 'WP_008705701.1' }, { 'peptide' => 'ISVAQGASK', 'refseq_protein_ids' => 'NP_003881.2 XP_011547112.1 XP_011547113.1' }, { 'peptide' => 'ISVAQGASK', 'refseq_protein_ids' => '' }]
+      output = "MDGTEYIIVK\tref|WP_008705701.1|\t100\t10\t0\t0\t0\t10\t0\t10\t1e-100\t100\nISVAQGASK\tref|NP_003881.2 XP_011547112.1 XP_011547113.1|\t100\t10\t0\t0\t0\t10\t0\t10\t1e-100\t100\n"
+      assert_equal(output, formatter.convert(object, true))
+      assert_equal(output, formatter.convert(object, false))
     end
   end
 


### PR DESCRIPTION
Adds a `--meganize` flag to pept2prot. Effect:
- enables `--all` and selects only the peptide and refseq_protein_ids
- outputs everything in a blasttab-like format

@ninewise Can you review this? I'll add some tests now


_[Original pull request](https://github.ugent.be/unipept/unipept-cli/pull/51) by @bmesuere on Wed Jan 18 2017 at 14:52._
_Merged by @bmesuere on Wed Jan 18 2017 at 15:37._