### PR TITLE
Fix for #66 (too much whitespace for GO)

### DIFF
--- a/lib/formatters.rb
+++ b/lib/formatters.rb
@@ -236,7 +236,7 @@ module Unipept
             if %w[ec go].include? k
               if v && !v.empty?
                 v.first.keys.each do |key|
-                  row << (v.map { |el| el[key] }).join(' ')
+                  row << (v.map { |el| el[key] }).join(' ').strip()
                 end
               else
                 row = row.concat(Array.new($keys_length[0], nil)) # rubocop:disable Style/GlobalVars


### PR DESCRIPTION
This PR strips the redundant whitespace that might occur after a list of GO terms.