### PR TITLE
Update pept2taxa.rb

### DIFF
--- a/lib/commands/unipept/pept2taxa.rb
+++ b/lib/commands/unipept/pept2taxa.rb
@@ -6,11 +6,7 @@ module Unipept::Commands
     end
 
     def default_batch_size
-      if options[:all]
-        5
-      else
-        10
-      end
+      5
     end
   end
 end

--- a/test/commands/unipept/test_pept2taxa.rb
+++ b/test/commands/unipept/test_pept2taxa.rb
@@ -5,8 +5,6 @@ module Unipept
     def test_default_batch_size
       command = Cri::Command.define { name 'pept2taxa' }
       pept2taxa = Commands::Pept2taxa.new({ host: 'http://api.unipept.ugent.be' }, [], command)
-      assert_equal(10, pept2taxa.default_batch_size)
-      pept2taxa.options[:all] = true
       assert_equal(5, pept2taxa.default_batch_size)
     end
 


### PR DESCRIPTION
Decrease the default batch size for `pept2taxa` to increase the chances of faster requests to get through the queue.