### PR TITLE
Fix UniProt command

### DIFF
--- a/lib/commands/uniprot.rb
+++ b/lib/commands/uniprot.rb
@@ -60,7 +60,7 @@ module Unipept::Commands
         get_uniprot_entry(accession, 'fasta').lines.map(&:chomp)[1..].join
       else
         # other format has been specified, just download and output
-        resp = Typhoeus.get("https://www.uniprot.org/uniprot/#{accession}.#{format}")
+        resp = Typhoeus.get("https://rest.uniprot.org/uniprotkb/#{accession}.#{format}")
         resp.response_body if resp.success?
       end
     end


### PR DESCRIPTION
An update of UniProt website caused our `uniprot` command to fail. This pull requests makes a change to the url to fix this.