### PR TITLE
Port peptfilter to typescript

### DIFF
--- a/bin/peptfilter.ts
+++ b/bin/peptfilter.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+import { Peptfilter } from '../lib/commands/peptfilter.js';
+
+const command = new Peptfilter();
+command.run();

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -104,7 +104,7 @@ const config: Config = {
   // notifyMode: "failure-change",
 
   // A preset that is used as a base for Jest's configuration
-  // preset: undefined,
+  preset: 'ts-jest/presets/default-esm',
 
   // Run tests from one or more projects
   // projects: undefined,

--- a/lib/commands/base_command.ts
+++ b/lib/commands/base_command.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { version } from '../../package.json';
+import { readFileSync } from "fs";
 
 /**
  * This is a base class which provides a common interface for all commands.
@@ -11,8 +11,10 @@ import { version } from '../../package.json';
 export abstract class BaseCommand {
   public program: Command;
   args: string[] | undefined;
+  version: string;
 
   constructor(options?: { exitOverride?: boolean, suppressOutput?: boolean, args?: string[] }) {
+    this.version = JSON.parse(readFileSync(new URL("../../package.json", import.meta.url), "utf8")).version;
     this.program = this.create(options);
     this.args = options?.args;
   }
@@ -37,8 +39,7 @@ export abstract class BaseCommand {
         writeErr: () => { }
       });
     }
-
-    program.version(version);
+    program.version(this.version);
 
     return program;
   }

--- a/lib/commands/peptfilter.ts
+++ b/lib/commands/peptfilter.ts
@@ -31,18 +31,19 @@ The input should have one peptide per line. FASTA headers are preserved in the o
     const lacks = this.program.opts().lacks || [];
     const contains = this.program.opts().contains || [];
 
+    // buffering output makes a big difference in performance
     let output = [];
     let i = 0;
 
     for await (const line of createInterface({ input: process.stdin })) {
       i++;
-      if (line.startsWith(">")) {
+      if (line.startsWith(">")) { // pass through FASTA headers
         output.push(line);
       } else if (Peptfilter.checkLength(line, minLen, maxlen) && Peptfilter.checkLacks(line, lacks) && Peptfilter.checkContains(line, contains)) {
         output.push(line);
       }
       if (i % 1000 === 0) {
-        output.push("");
+        output.push(""); //add a newline at the end of the buffer without additional string copy
         process.stdout.write(output.join("\n"));
         output = [];
       }

--- a/lib/commands/peptfilter.ts
+++ b/lib/commands/peptfilter.ts
@@ -22,9 +22,8 @@ The input should have one peptide per line. FASTA headers are preserved in the o
 
   async run() {
     this.parseArguments();
-    console.log(this.program.opts())
-    const minLen = this.program.opts().minLen;
-    const maxlen = this.program.opts().maxLen;
+    const minLen = this.program.opts().minlen;
+    const maxlen = this.program.opts().maxlen;
     const lacks = this.program.opts().lacks || [];
     const contains = this.program.opts().contains || [];
 
@@ -33,6 +32,7 @@ The input should have one peptide per line. FASTA headers are preserved in the o
         process.stdout.write(line + "\n");
         continue;
       }
+
       if (Peptfilter.checkLength(line, minLen, maxlen) && Peptfilter.checkLacks(line, lacks) && Peptfilter.checkContains(line, contains)) {
         process.stdout.write(line + "\n");
       }

--- a/lib/commands/peptfilter.ts
+++ b/lib/commands/peptfilter.ts
@@ -1,0 +1,53 @@
+import { Option } from 'commander';
+import { createInterface } from 'node:readline';
+import { BaseCommand } from './base_command.js';
+
+export class Peptfilter extends BaseCommand {
+
+  readonly description = `The peptfilter command filters a list of peptides according to specific criteria. The command expects a list of peptides that are passed to standard input.
+
+The input should have one peptide per line. FASTA headers are preserved in the output, so that peptides remain bundled.`;
+
+  constructor(options?: { exitOverride?: boolean, suppressOutput?: boolean, args?: string[] }) {
+    super(options);
+
+    this.program
+      .summary("Filter peptides based on specific criteria.")
+      .description(this.description)
+      .option("--minlen <length>", "only retain peptides having at least this many amino acids", (d) => parseInt(d, 10), 5)
+      .option("--maxlen <length>", "only retain peptides having at most this many amino acids", (d) => parseInt(d, 10), 50)
+      .option("-l, --lacks <amino acids>", "only retain peptides that lack all of the specified amino acids", (d) => d.split(""))
+      .option("-c, --contains <amino acids>", "only retain peptides that contain all of the specified amino acids", (d) => d.split(""));
+  }
+
+  async run() {
+    this.parseArguments();
+    console.log(this.program.opts())
+    const minLen = this.program.opts().minLen;
+    const maxlen = this.program.opts().maxLen;
+    const lacks = this.program.opts().lacks || [];
+    const contains = this.program.opts().contains || [];
+
+    for await (const line of createInterface({ input: process.stdin })) {
+      if (line.startsWith(">")) {
+        process.stdout.write(line + "\n");
+        continue;
+      }
+      if (Peptfilter.checkLength(line, minLen, maxlen) && Peptfilter.checkLacks(line, lacks) && Peptfilter.checkContains(line, contains)) {
+        process.stdout.write(line + "\n");
+      }
+    }
+  }
+
+  static checkLength(line: string, minLen: number, maxlen: number): boolean {
+    return line.length >= minLen && line.length <= maxlen;
+  }
+
+  static checkLacks(line: string, lacks: string[]): boolean {
+    return lacks.every((aa: string) => !line.includes(aa));
+  }
+
+  static checkContains(line: string, contains: string[]): boolean {
+    return contains.every((aa: string) => line.includes(aa));
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "yarn run tsc",
     "lint": "yarn run eslint",
-    "test": "yarn run jest",
+    "test": "NODE_OPTIONS='--experimental-vm-modules --no-warnings' yarn run jest",
     "typecheck": "yarn tsc --skipLibCheck --noEmit",
     "peptfilter": "yarn run tsx bin/peptfilter.ts",
     "uniprot": "yarn run tsx bin/uniprot.ts"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "private": false,
   "type": "module",
   "bin": {
+    "peptfilter": "./bin/peptfilter.js",
     "uniprot": "./bin/uniprot.js"
   },
   "scripts": {
@@ -15,6 +16,7 @@
     "lint": "yarn run eslint",
     "test": "yarn run jest",
     "typecheck": "yarn tsc --skipLibCheck --noEmit",
+    "peptfilter": "yarn run tsx bin/peptfilter.ts",
     "uniprot": "yarn run tsx bin/uniprot.ts"
   },
   "dependencies": {

--- a/tests/commands/peptfilter.test.ts
+++ b/tests/commands/peptfilter.test.ts
@@ -1,0 +1,98 @@
+import { Peptfilter } from '../../lib/commands/peptfilter';
+import * as mock from 'mock-stdin';
+
+let output: string[];
+let error: string[];
+const writeSpy = jest
+  .spyOn(process.stdout, "write")
+  .mockImplementation((data: unknown) => { output.push(data as string); return true; });
+const errorSpy = jest
+  .spyOn(process.stderr, "write")
+  .mockImplementation((data: unknown) => { error.push(data as string); return true; });
+
+beforeEach(() => {
+  output = [];
+  error = [];
+});
+
+test('test length filter', async () => {
+  // min length
+  expect(Peptfilter.checkLength('AALER', 4, 10)).toBe(true);
+  expect(Peptfilter.checkLength('AALER', 5, 10)).toBe(true);
+  expect(Peptfilter.checkLength('AALER', 6, 10)).toBe(false);
+
+  // max length
+  expect(Peptfilter.checkLength('AALER', 1, 4)).toBe(false);
+  expect(Peptfilter.checkLength('AALER', 1, 5)).toBe(true);
+  expect(Peptfilter.checkLength('AALER', 1, 6)).toBe(true);
+});
+
+test('test lacks filter', async () => {
+  expect(Peptfilter.checkLacks('AALER', ''.split(""))).toBe(true);
+  expect(Peptfilter.checkLacks('AALER', 'BCD'.split(""))).toBe(true);
+  expect(Peptfilter.checkLacks('AALER', 'A'.split(""))).toBe(false);
+  expect(Peptfilter.checkLacks('AALER', 'AE'.split(""))).toBe(false);
+});
+
+test('test contains filter', async () => {
+  expect(Peptfilter.checkContains('AALER', ''.split(""))).toBe(true);
+  expect(Peptfilter.checkContains('AALER', 'A'.split(""))).toBe(true);
+  expect(Peptfilter.checkContains('AALER', 'AE'.split(""))).toBe(true);
+  expect(Peptfilter.checkContains('AALER', 'BCD'.split(""))).toBe(false);
+  expect(Peptfilter.checkContains('AALER', 'AB'.split(""))).toBe(false);
+});
+
+test('test default filter from stdin', async () => {
+  const stdin = mock.stdin();
+
+  const command = new Peptfilter();
+  const run = command.run();
+
+  stdin.send("AAAA\n");
+  stdin.send("AAAAA\n");
+  stdin.end();
+
+  await run;
+
+  expect(writeSpy).toHaveBeenCalledTimes(1);
+  expect(errorSpy).toHaveBeenCalledTimes(0);
+  expect(output.length).toBe(1);
+});
+
+test('test if it passes fasta from stdin', async () => {
+  const stdin = mock.stdin();
+
+  const command = new Peptfilter();
+  const run = command.run();
+
+  stdin.send(">AA\n");
+  stdin.send("AAA\n");
+  stdin.end();
+
+  await run;
+
+  expect(writeSpy).toHaveBeenCalledTimes(1);
+  expect(errorSpy).toHaveBeenCalledTimes(0);
+  expect(output[0]).toBe(">AA\n");
+});
+
+test('test complex example from stdin', async () => {
+  const stdin = mock.stdin();
+
+  const command = new Peptfilter({ args: ["--minlen", "4", "--maxlen", "10", "--lacks", "B", "--contains", "A"] });
+  const run = command.run();
+
+  stdin.send("A\n");
+  stdin.send("AAAAAAAAAAA\n");
+  stdin.send("AAAAB\n");
+  stdin.send("BBBBB\n");
+  stdin.send("CCCCC\n");
+  stdin.send("CCCCCA\n");
+  stdin.end();
+
+  await run;
+
+  expect(writeSpy).toHaveBeenCalledTimes(1);
+  expect(errorSpy).toHaveBeenCalledTimes(0);
+  expect(output[0]).toBe("CCCCCA\n");
+});

--- a/tests/commands/peptfilter.test.ts
+++ b/tests/commands/peptfilter.test.ts
@@ -1,4 +1,5 @@
 import { Peptfilter } from '../../lib/commands/peptfilter';
+import { jest } from '@jest/globals';
 import * as mock from 'mock-stdin';
 
 let output: string[];
@@ -54,9 +55,8 @@ test('test default filter from stdin', async () => {
 
   await run;
 
-  expect(writeSpy).toHaveBeenCalledTimes(1);
   expect(errorSpy).toHaveBeenCalledTimes(0);
-  expect(output.length).toBe(1);
+  expect(output.join("").trimEnd().split("\n").length).toBe(1);
 });
 
 test('test if it passes fasta from stdin', async () => {
@@ -71,8 +71,8 @@ test('test if it passes fasta from stdin', async () => {
 
   await run;
 
-  expect(writeSpy).toHaveBeenCalledTimes(1);
   expect(errorSpy).toHaveBeenCalledTimes(0);
+  expect(output.join("").trimEnd().split("\n").length).toBe(1);
   expect(output[0]).toBe(">AA\n");
 });
 
@@ -92,7 +92,7 @@ test('test complex example from stdin', async () => {
 
   await run;
 
-  expect(writeSpy).toHaveBeenCalledTimes(1);
   expect(errorSpy).toHaveBeenCalledTimes(0);
+  expect(output.join("").trimEnd().split("\n").length).toBe(1);
   expect(output[0]).toBe("CCCCCA\n");
 });

--- a/tests/commands/peptfilter.test.ts
+++ b/tests/commands/peptfilter.test.ts
@@ -4,6 +4,7 @@ import * as mock from 'mock-stdin';
 
 let output: string[];
 let error: string[];
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const writeSpy = jest
   .spyOn(process.stdout, "write")
   .mockImplementation((data: unknown) => { output.push(data as string); return true; });

--- a/tests/commands/uniprot.test.ts
+++ b/tests/commands/uniprot.test.ts
@@ -1,4 +1,5 @@
 import { Uniprot } from '../../lib/commands/uniprot';
+import { jest } from '@jest/globals';
 import * as mock from 'mock-stdin';
 
 let output: string[];


### PR DESCRIPTION
This PR reimplements the peptfilter command in typescript.

I ran peptfilter on swissprot as a benchmark.
The original ruby code took 25 seconds, the reimplementation takes 4 seconds.