### PR TITLE
Fix protinfo tests for new name field

### DIFF
--- a/tests/commands/unipept/protinfo.test.ts
+++ b/tests/commands/unipept/protinfo.test.ts
@@ -13,15 +13,15 @@ beforeEach(() => {
 test('test with default args', async () => {
   const command = new Protinfo();
   await command.run(["P78330"], { header: true, format: "csv" });
-  expect(output[0].startsWith("protein,taxon_id,taxon_name,taxon_rank,ec_number,go_term,ipr_code")).toBeTruthy();
-  expect(output[1].startsWith("P78330,9606,Homo sapiens")).toBeTruthy();
+  expect(output[0].startsWith("protein,name,taxon_id,taxon_name,taxon_rank,ec_number,go_term,ipr_code")).toBeTruthy();
+  expect(output[1].startsWith("P78330,Phosphoserine phosphatase,9606,Homo sapiens")).toBeTruthy();
   expect(output.length).toBe(2);
 });
 
 test('test with fasta', async () => {
   const command = new Protinfo();
   await command.run([">test", "P78330"], { header: true, format: "csv" });
-  expect(output[0].startsWith("fasta_header,protein,taxon_id,taxon_name,taxon_rank,ec_number,go_term,ipr_code")).toBeTruthy();
-  expect(output[1].startsWith(">test,P78330,9606,Homo sapiens")).toBeTruthy();
+  expect(output[0].startsWith("fasta_header,protein,name,taxon_id,taxon_name,taxon_rank,ec_number,go_term,ipr_code")).toBeTruthy();
+  expect(output[1].startsWith(">test,P78330,Phosphoserine phosphatase,9606,Homo sapiens")).toBeTruthy();
   expect(output.length).toBe(2);
 });


### PR DESCRIPTION
Protinfo now also returns the protein name which broke the tests. This PR adapts the tests to the added field.